### PR TITLE
Soil temp error branch

### DIFF
--- a/SW_Flow.c
+++ b/SW_Flow.c
@@ -663,8 +663,8 @@ void SW_Water_Flow(void) {
 	/* Soil Temperature starts here */
 
 	double biomass; // computing the live biomass real quickly to condense the call to soil_temperature
-biomass = SW_VegProd.grass.biolive_daily[doy] * SW_VegProd.fractionGrass + SW_VegProd.shrub.biolive_daily[doy] * SW_VegProd.fractionShrub
-		+ SW_VegProd.forb.biolive_daily[doy] * SW_VegProd.fractionForb + SW_VegProd.tree.biolive_daily[doy] * SW_VegProd.fractionTree; // changed to exclude tree biomass, bMatric/c it was breaking the soil_temperature function
+biomass = SW_VegProd.grass.biomass_daily[doy] * SW_VegProd.fractionGrass + SW_VegProd.shrub.biolive_daily[doy] * SW_VegProd.fractionShrub
+		+ SW_VegProd.forb.biomass_daily[doy] * SW_VegProd.fractionForb + SW_VegProd.tree.biolive_daily[doy] * SW_VegProd.fractionTree; // changed to exclude tree biomass, bMatric/c it was breaking the soil_temperature function
 
 			// soil_temperature function computes the soil temp for each layer and stores it in lyrsTemp
 			// doesn't affect SWC at all, but needs it for the calculation, so therefore the temperature is the last calculation done

--- a/SW_Flow.c
+++ b/SW_Flow.c
@@ -120,7 +120,6 @@
 #include "SW_VegProd.h"
 #include "SW_Weather.h"
 #include "SW_Sky.h"
-
 /* =================================================== */
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
@@ -164,6 +163,38 @@ static RealD surfaceTemp[TWO_DAYS], forb_h2o_qum[TWO_DAYS], tree_h2o_qum[TWO_DAY
 /* --------------------------------------------------- */
 static void records2arrays(void);
 static void arrays2records(void);
+
+/* =================================================== */
+/*                RSOILWAT						                 */
+/* --------------------------------------------------- */
+#ifdef RSOILWAT
+SEXP tempError()
+{
+	SEXP swR_temp_error;
+	PROTECT(swR_temp_error = NEW_LOGICAL(1));
+
+	int i;
+	int Rsoil_temp_error = 0;
+	for (i = 0; i < MAX_LAYERS - 1; i++)
+	{
+		if (SW_Soilwat.parts[i] >= 1)
+		{
+			Rsoil_temp_error = 1;
+		}
+	}
+
+	if (Rsoil_temp_error == 1)
+	{
+		LOGICAL_POINTER(swR_temp_error)[0] = TRUE;
+	}
+	else
+	{
+		LOGICAL_POINTER(swR_temp_error)[0] = FALSE;
+	}
+	UNPROTECT(1);
+	return swR_temp_error;
+}
+#endif
 
 /* *************************************************** */
 /* *************************************************** */

--- a/SW_Flow_lib.c
+++ b/SW_Flow_lib.c
@@ -102,33 +102,16 @@
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
 extern SW_SITE SW_Site;
+extern SW_SOILWAT SW_Soilwat;
 unsigned int soil_temp_error;  // simply keeps track of whether or not an error has been reported in the soil_temperature function.  0 for no, 1 for yes.
 unsigned int soil_temp_init;   // simply keeps track of whether or not the values for the soil_temperature function have been initialized.  0 for no, 1 for yes.
 unsigned int fusion_pool_init;   // simply keeps track of whether or not the values for the soil fusion (thawing/freezing) section of the soil_temperature function have been initialized.  0 for no, 1 for yes.
-unsigned int Rsoil_temp_error = 0;
 /* *************************************************** */
 /*                Module-Level Variables               */
 /* --------------------------------------------------- */
 
 static ST_RGR_VALUES stValues; // keeps track of the soil_temperature values
 
-#ifdef RSOILWAT
-SEXP tempError()
-{
-	SEXP swR_temp_error;
-	PROTECT(swR_temp_error = NEW_LOGICAL(1));
-	if (Rsoil_temp_error == 1)
-	{
-		LOGICAL_POINTER(swR_temp_error)[0] = TRUE;
-	}
-	else
-	{
-		LOGICAL_POINTER(swR_temp_error)[0] = FALSE;
-	}
-	UNPROTECT(1);
-	return swR_temp_error;
-}
-#endif
 /* *************************************************** */
 /* *************************************************** */
 /*              Local Function Definitions             */
@@ -1785,6 +1768,7 @@ void soil_temperature(double airTemp, double pet, double aet, double biomass, do
 		sh = vwcR[k] + shParam * (1. - vwcR[k]); // Parton (1978) eq. 2.22: specific heat capacity; shParam = 0.18
 			// TODO: adjust thermal conductivity and heat capacity if layer is frozen
 		parts = part1 * cs / (sh * st->bDensityR[k]);
+		SW_Soilwat.parts[i] = parts;
 
 		part2 = sTempR[i - 1] - 2 * st->oldsTempR[i] + st->oldsTempR[i + 1];
 
@@ -1795,8 +1779,6 @@ void soil_temperature(double airTemp, double pet, double aet, double biomass, do
 				printf("\n SOILWAT has encountered an ERROR: Parts Exceeds 1.0 and May Produce Extreme Values");
 				soil_temp_error = 1;
 			#else
-				Rprintf("\n parts : %f\n", parts);
-				Rsoil_temp_error = 1;
 			#endif
 			// return;  //Exits the Function
 		}

--- a/SW_Flow_lib.c
+++ b/SW_Flow_lib.c
@@ -105,7 +105,7 @@ extern SW_SITE SW_Site;
 unsigned int soil_temp_error;  // simply keeps track of whether or not an error has been reported in the soil_temperature function.  0 for no, 1 for yes.
 unsigned int soil_temp_init;   // simply keeps track of whether or not the values for the soil_temperature function have been initialized.  0 for no, 1 for yes.
 unsigned int fusion_pool_init;   // simply keeps track of whether or not the values for the soil fusion (thawing/freezing) section of the soil_temperature function have been initialized.  0 for no, 1 for yes.
-
+unsigned int Rsoil_temp_error;
 /* *************************************************** */
 /*                Module-Level Variables               */
 /* --------------------------------------------------- */
@@ -117,7 +117,7 @@ SEXP tempError()
 {
 	SEXP swR_temp_error;
 	PROTECT(swR_temp_error = NEW_LOGICAL(1));
-	if (soil_temp_error == 1)
+	if (Rsoil_temp_error == 1)
 	{
 		LOGICAL_POINTER(swR_temp_error)[0] = TRUE;
 	}
@@ -1790,13 +1790,12 @@ void soil_temperature(double airTemp, double pet, double aet, double biomass, do
 
 		/*Parton, W. J. 1984. Predicting Soil Temperatures in A Shortgrass Steppe. Soil Science 138:93-101.
 		VWCnew: why 0.5 and not 1? and they use a fixed alpha * K whereas here it is 1/(cs * sh)*/
-		if (GT(parts, 1.0)){
+		if (GE(parts, 1.0)){
 			#ifndef RSOILWAT
 				printf("\n SOILWAT has encountered an ERROR: Parts Exceeds 1.0 and May Produce Extreme Values");
 				soil_temp_error = 1;
 			#else
-				Rprintf("\n SOILWAT has encountered an ERROR: Parts Exceeds 1.0 and May Produce Extreme Values");
-				soil_temp_error = 1;
+				Rsoil_temp_error = 1;
 			#endif
 			// return;  //Exits the Function
 		}

--- a/SW_Flow_lib.c
+++ b/SW_Flow_lib.c
@@ -1787,7 +1787,6 @@ void soil_temperature(double airTemp, double pet, double aet, double biomass, do
 		sh = vwcR[k] + shParam * (1. - vwcR[k]); // Parton (1978) eq. 2.22: specific heat capacity; shParam = 0.18
 			// TODO: adjust thermal conductivity and heat capacity if layer is frozen
 		parts = part1 * cs / (sh * st->bDensityR[k]);
-		SW_Soilwat.parts[i] = parts;
 
 		part2 = sTempR[i - 1] - 2 * st->oldsTempR[i] + st->oldsTempR[i + 1];
 

--- a/SW_Flow_lib.c
+++ b/SW_Flow_lib.c
@@ -105,7 +105,7 @@ extern SW_SITE SW_Site;
 unsigned int soil_temp_error;  // simply keeps track of whether or not an error has been reported in the soil_temperature function.  0 for no, 1 for yes.
 unsigned int soil_temp_init;   // simply keeps track of whether or not the values for the soil_temperature function have been initialized.  0 for no, 1 for yes.
 unsigned int fusion_pool_init;   // simply keeps track of whether or not the values for the soil fusion (thawing/freezing) section of the soil_temperature function have been initialized.  0 for no, 1 for yes.
-unsigned int Rsoil_temp_error;
+unsigned int Rsoil_temp_error = 0;
 /* *************************************************** */
 /*                Module-Level Variables               */
 /* --------------------------------------------------- */
@@ -1795,6 +1795,7 @@ void soil_temperature(double airTemp, double pet, double aet, double biomass, do
 				printf("\n SOILWAT has encountered an ERROR: Parts Exceeds 1.0 and May Produce Extreme Values");
 				soil_temp_error = 1;
 			#else
+				Rprintf("\n parts : %f\n", parts);
 				Rsoil_temp_error = 1;
 			#endif
 			// return;  //Exits the Function

--- a/SW_Flow_lib.c
+++ b/SW_Flow_lib.c
@@ -102,11 +102,9 @@
 /*                  Global Variables                   */
 /* --------------------------------------------------- */
 extern SW_SITE SW_Site;
-extern SW_SOILWAT SW_Soilwat;
 unsigned int soil_temp_error;  // simply keeps track of whether or not an error has been reported in the soil_temperature function.  0 for no, 1 for yes.
 unsigned int soil_temp_init;   // simply keeps track of whether or not the values for the soil_temperature function have been initialized.  0 for no, 1 for yes.
 unsigned int fusion_pool_init;   // simply keeps track of whether or not the values for the soil fusion (thawing/freezing) section of the soil_temperature function have been initialized.  0 for no, 1 for yes.
-unsigned int count;
 
 /* *************************************************** */
 /*                Module-Level Variables               */

--- a/SW_Flow_lib.h
+++ b/SW_Flow_lib.h
@@ -67,9 +67,15 @@ typedef struct {
 		   oldsFusionPool_actual[MAX_LAYERS],
 		   oldsTempR[MAX_ST_RGR + 1];//yesterdays soil temperature of soil layers for soil temperature calculations; index 0 is surface temperature
 
+	double errorTemp[MAX_LAYERS];
+ 	double pe[MAX_LAYERS];
+ 	double cs[MAX_LAYERS];
+ 	double sh[MAX_LAYERS];
+ 	double part1[MAX_LAYERS];
+ 	double parts[MAX_LAYERS];
+
 	int lyrFrozen[MAX_LAYERS];
 	double tlyrs_by_slyrs[MAX_ST_RGR + 1][MAX_LAYERS + 1]; // array of soil depth correspondance between soil profile layers and soil temperature layers; last column has negative values and indicates use of deepest soil layer values copied for deeper soil temperature layers
-
 	/*unsigned int x1BoundsR[MAX_ST_RGR],
 	             x2BoundsR[MAX_ST_RGR],
 				 x1Bounds[MAX_LAYERS],

--- a/SW_Flow_lib.h
+++ b/SW_Flow_lib.h
@@ -67,15 +67,9 @@ typedef struct {
 		   oldsFusionPool_actual[MAX_LAYERS],
 		   oldsTempR[MAX_ST_RGR + 1];//yesterdays soil temperature of soil layers for soil temperature calculations; index 0 is surface temperature
 
-	double errorTemp[MAX_LAYERS];
- 	double pe[MAX_LAYERS];
- 	double cs[MAX_LAYERS];
- 	double sh[MAX_LAYERS];
- 	double part1[MAX_LAYERS];
- 	double parts[MAX_LAYERS];
-
 	int lyrFrozen[MAX_LAYERS];
 	double tlyrs_by_slyrs[MAX_ST_RGR + 1][MAX_LAYERS + 1]; // array of soil depth correspondance between soil profile layers and soil temperature layers; last column has negative values and indicates use of deepest soil layer values copied for deeper soil temperature layers
+
 	/*unsigned int x1BoundsR[MAX_ST_RGR],
 	             x2BoundsR[MAX_ST_RGR],
 				 x1Bounds[MAX_LAYERS],

--- a/SW_Output.c
+++ b/SW_Output.c
@@ -149,7 +149,9 @@ SW_OUT_flush() calls at end of year and SW_Control.c/_collect_values() calls dai
  07/09/2013	(clk)	Added forb to the outputs: transpiration, surface evaporation, interception, and hydraulic redistribution
  08/21/2013	(clk)	Modified the establisment output to actually output for each species and not just the last one in the group.
  06/23/2015 (akt)	Added output for surface temperature to get_temp()
-
+ 02/25/2016 (ctd) Added PARTSERROR as an output for both SOILWAT and RSOILWAT
+ 									(i.e. added enum and keystring to key2str, key2obj, added get_partserror() with call in construct(),
+									added RSOILWAT pointer and calls to parts in average_for() and sumof_swc())
  */
 /********************************************************/
 /********************************************************/
@@ -178,7 +180,6 @@ SW_OUT_flush() calls at end of year and SW_Control.c/_collect_values() calls dai
 #include "SW_Output.h"
 #include "SW_Weather.h"
 #include "SW_VegEstab.h"
-#include "SW_Flow_lib.h"
 
 #ifdef RSOILWAT
 #include "R.h"
@@ -196,7 +197,6 @@ extern SW_SOILWAT SW_Soilwat;
 extern SW_MODEL SW_Model;
 extern SW_WEATHER SW_Weather;
 extern SW_VEGESTAB SW_VegEstab;
-extern ST_RGR_VALUES stValues;
 extern Bool EchoInits;
 
 #define OUTSTRLEN 3000 /* max output string length: in get_transp: 4*every soil layer with 14 chars */
@@ -215,7 +215,7 @@ extern RealD *p_Raet_wk, *p_Rdeep_drain_wk, *p_Restabs_wk, *p_Revap_soil_wk, *p_
 		*p_RswaBulk_wk, *p_RswaMatric_wk, *p_Rtemp_wk, *p_Rtransp_wk, *p_Rwetdays_wk;
 extern RealD *p_Raet_dy, *p_Rdeep_drain_dy, *p_Restabs_dy, *p_Revap_soil_dy, *p_Revap_surface_dy, *p_Rhydred_dy, *p_Rinfiltration_dy, *p_Rinterception_dy, *p_Rpercolation_dy,
 		*p_Rpet_dy, *p_Rprecip_dy, *p_Rrunoff_dy, *p_Rsnowpack_dy, *p_Rsoil_temp_dy, *p_Rsurface_water_dy, *p_RvwcBulk_dy, *p_RvwcMatric_dy, *p_RswcBulk_dy, *p_RswpMatric_dy,
-		*p_RswaBulk_dy, *p_RswaMatric_dy, *p_Rtemp_dy, *p_Rtransp_dy, *p_Rwetdays_dy;
+		*p_RswaBulk_dy, *p_RswaMatric_dy, *p_Rtemp_dy, *p_Rtransp_dy, *p_Rwetdays_dy, *p_Rsoil_temp_dy;
 extern unsigned int yr_nrow, mo_nrow, wk_nrow, dy_nrow;
 #endif
 
@@ -243,12 +243,12 @@ static TimeInt tOffset; /* 1 or 0 means we're writing previous or current period
  * SW_Output.h */
 static char *key2str[] = { SW_WETHR, SW_TEMP, SW_PRECIP, SW_SOILINF, SW_RUNOFF, SW_ALLH2O, SW_VWCBULK, SW_VWCMATRIC, SW_SWCBULK, SW_SWABULK, SW_SWAMATRIC, SW_SWPMATRIC,
 		SW_SURFACEW, SW_TRANSP, SW_EVAPSOIL, SW_EVAPSURFACE, SW_INTERCEPTION, SW_LYRDRAIN, SW_HYDRED, SW_ET, SW_AET, SW_PET, SW_WETDAY, SW_SNOWPACK, SW_DEEPSWC, SW_SOILTEMP,
-		SW_ALLVEG, SW_ESTAB, SW_ERRORTEMP };
+		SW_PARTSERROR, SW_ALLVEG, SW_ESTAB };
 /* converts an enum output key (OutKey type) to a module  */
 /* or object type. see SW_Output.h for OutKey order.         */
 /* MUST be SW_OUTNKEYS of these */
 static ObjType key2obj[] = { eWTH, eWTH, eWTH, eWTH, eWTH, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC, eSWC,
-		eSWC, eSWC, eVES, eVES, eVES };
+		eSWC, eSWC, eSWC, eVES, eVES };
 static char *pd2str[] = { SW_DAY, SW_WEEK, SW_MONTH, SW_YEAR };
 static char *styp2str[] = { SW_SUM_OFF, SW_SUM_SUM, SW_SUM_AVG, SW_SUM_FNL };
 
@@ -285,7 +285,7 @@ static void get_snowpack(void);
 static void get_deepswc(void);
 static void get_estab(void);
 static void get_soiltemp(void);
-static void get_errorTemp(void);
+static void get_partserror(void);
 static void get_none(void); /* default until defined */
 
 static void collect_sums(ObjType otyp, OutPeriod op);
@@ -431,12 +431,12 @@ void SW_OUT_construct(void) {
 		case eSW_SoilTemp:
 			SW_Output[k].pfunc = (void (*)(void)) get_soiltemp;
 			break;
+    case eSW_PartsError:
+      SW_Output[k].pfunc = (void (*)(void)) get_partserror;
+      break;
 		case eSW_Estab:
 			SW_Output[k].pfunc = (void (*)(void)) get_estab;
 			break;
-    case eSW_ErrTemp:
-      SW_Output[k].pfunc = (void (*)(void)) get_errorTemp;
-      break;
 		default:
 			SW_Output[k].pfunc = (void (*)(void)) get_none;
 			break;
@@ -3243,39 +3243,39 @@ static void get_deepswc(void) {
 #endif
 }
 
-static void get_errorTemp(void){
-  ST_RGR_VALUES *v = &stValues;
-  OutPeriod pd = SW_Output[eSW_ErrTemp].period;
-	LyrIndex i;
-#ifndef RSOILWAT
-  RealD et = SW_MISSING;
-  RealD pe = SW_MISSING;
-  RealD cs = SW_MISSING;
-  RealD sh = SW_MISSING;
-  RealD part1 = SW_MISSING;
-  RealD parts = SW_MISSING;
+static void get_partserror(void)
+{
+  LyrIndex i; /** Check parts at each soil layer */
+  SW_SOILWAT *v = &SW_Soilwat; /** Structure containing parts output */
+  OutPeriod pd = SW_Output[eSW_PartsError].period;
 
+#ifndef RSOILWAT
+  RealD val = SW_MISSING;
   char str[OUTSTRLEN];
   get_outstrleader(pd);
-	ForEachSoilLayer(i)
-	{
-	  switch (pd) {
-	    case eSW_Day:
-	      et = v->errorTemp[i + 1];
-	      pe = v->pe[i + 1];
-	      cs = v->cs[i + 1];
-	      sh = v->sh[i + 1];
-	      part1 = v->part1[i + 1];
-	      parts = v->parts[i + 1];
-	    default:
-	      break;
-	    }
-		sprintf(str, "\n%c%c%7.8f%c%7.8f%c%7.8f%c%7.8f%c%7.8f%c%7.8f", _Sep, _Sep, et, _Sep, pe, _Sep, cs, _Sep, sh, _Sep, part1, _Sep, parts);
-		strcat(outstr, str);
-	}
-#endif
-  }
 
+  ForEachSoilLayer(i)
+  {
+    switch(pd)
+    {
+      case eSW_Day:
+        if (v->parts[i] >= .99999) /** arbitrary value */
+        {
+          val = 1; /** Not concerned with value of parts but the threshold being crossed */
+        }
+        else
+        {
+          val = 0;
+        }
+        break;
+      default:  /** Only concerned with parts for the day */
+        break;
+    }
+    sprintf(str, "%c%7.6f", _Sep, val);
+		strcat(outstr, str);
+  }
+#endif
+}
 
 static void get_soiltemp(void) {
 	/* --------------------------------------------------- */
@@ -3516,6 +3516,11 @@ static void sumof_swc(SW_SOILWAT *v, SW_SOILWAT_OUTPUTS *s, OutKey k) {
 			s->sTemp[i] += v->sTemp[i];
 		break;
 
+  case eSW_PartsError:
+    ForEachSoilLayer(i)
+      s->parts[i] += v->parts[i];
+    break;
+
 	default:
 		LogError(stderr, LOGFATAL, "PGMR: Invalid key in sumof_swc(%s)", key2str[k]);
 	}
@@ -3619,6 +3624,11 @@ static void average_for(ObjType otyp, OutPeriod pd) {
 					ForEachSoilLayer(i)
 						savg->sTemp[i] = (SW_Output[k].sumtype == eSW_Fnl) ? SW_Soilwat.sTemp[i] : ssumof->sTemp[i] / div;
 					break;
+
+        case eSW_PartsError:
+          ForEachSoilLayer(i)
+            savg->parts[i] = (SW_Output[k].sumtype == eSW_Fnl) ? SW_Soilwat.parts[i] : ssumof->parts[i] / div;
+          break;
 
 				case eSW_VWCBulk:
 					ForEachSoilLayer(i)

--- a/SW_Output.h
+++ b/SW_Output.h
@@ -72,8 +72,9 @@
 #define SW_SOILTEMP		"SOILTEMP"		//25	4		2
 #define SW_ALLVEG		"ALLVEG"		//26	5		0/* position and variable marker, not an output key */
 #define SW_ESTAB		"ESTABL"		//27	5		0
+#define SW_ERRORTEMP "ERRTEMP" // 28 
 
-#define SW_OUTNKEYS 28 /* must also match number of items in enum (minus eSW_NoKey and eSW_LastKey) */
+#define SW_OUTNKEYS 29 /* must also match number of items in enum (minus eSW_NoKey and eSW_LastKey) */
 
 /* these are the code analog of the above */
 /* see also key2str[] in Output.c */
@@ -110,8 +111,9 @@ typedef enum {
 	eSW_SoilTemp,
 	/* vegetation quantities */
 	eSW_AllVeg,
-	eSW_Estab, /* make sure this is the last one */
-	eSW_LastKey
+	eSW_Estab,
+	eSW_ErrTemp,
+	eSW_LastKey /* make sure this is the last one */
 } OutKey;
 
 /* output period specifiers found in input file */

--- a/SW_Output.h
+++ b/SW_Output.h
@@ -71,11 +71,10 @@
 #define SW_SNOWPACK		"SNOWPACK"		//23	4		2
 #define SW_DEEPSWC		"DEEPSWC"		//24	4		1
 #define SW_SOILTEMP		"SOILTEMP"		//25	4		2
-#define SW_PARTSERROR 		"PARTSERROR"			//26
 #define SW_ALLVEG		"ALLVEG"		//27	5		0/* position and variable marker, not an output key */
 #define SW_ESTAB		"ESTABL"		//28	5		0
 
-#define SW_OUTNKEYS 29 /* must also match number of items in enum (minus eSW_NoKey and eSW_LastKey) */
+#define SW_OUTNKEYS 28 /* must also match number of items in enum (minus eSW_NoKey and eSW_LastKey) */
 
 /* these are the code analog of the above */
 /* see also key2str[] in Output.c */
@@ -110,7 +109,6 @@ typedef enum {
 	eSW_SnowPack,
 	eSW_DeepSWC,
 	eSW_SoilTemp,
-	eSW_PartsError,
 	/* vegetation quantities */
 	eSW_AllVeg,
 	eSW_Estab, /* make sure this is the last one */

--- a/SW_Output.h
+++ b/SW_Output.h
@@ -71,8 +71,8 @@
 #define SW_SNOWPACK		"SNOWPACK"		//23	4		2
 #define SW_DEEPSWC		"DEEPSWC"		//24	4		1
 #define SW_SOILTEMP		"SOILTEMP"		//25	4		2
-#define SW_ALLVEG		"ALLVEG"		//27	5		0/* position and variable marker, not an output key */
-#define SW_ESTAB		"ESTABL"		//28	5		0
+#define SW_ALLVEG		"ALLVEG"		//26	5		0/* position and variable marker, not an output key */
+#define SW_ESTAB		"ESTABL"		//27	5		0
 
 #define SW_OUTNKEYS 28 /* must also match number of items in enum (minus eSW_NoKey and eSW_LastKey) */
 

--- a/SW_Output.h
+++ b/SW_Output.h
@@ -24,6 +24,7 @@
 	01/10/2013	(clk)	instead of using one FILE pointer named fp, created four new
 			FILE pointers; fp_dy, fp_wk, fp_mo, and fp_yr. This allows us to keep track
 			of all time steps for each OutKey.
+	02/25/2016 (ctd) added parts as an output (i.e. added macro definition, key string, incremented SW_OUTNKEYS)
 */
 /********************************************************/
 /********************************************************/
@@ -70,9 +71,9 @@
 #define SW_SNOWPACK		"SNOWPACK"		//23	4		2
 #define SW_DEEPSWC		"DEEPSWC"		//24	4		1
 #define SW_SOILTEMP		"SOILTEMP"		//25	4		2
-#define SW_ALLVEG		"ALLVEG"		//26	5		0/* position and variable marker, not an output key */
-#define SW_ESTAB		"ESTABL"		//27	5		0
-#define SW_ERRORTEMP "ERRTEMP" // 28 
+#define SW_PARTSERROR 		"PARTSERROR"			//26
+#define SW_ALLVEG		"ALLVEG"		//27	5		0/* position and variable marker, not an output key */
+#define SW_ESTAB		"ESTABL"		//28	5		0
 
 #define SW_OUTNKEYS 29 /* must also match number of items in enum (minus eSW_NoKey and eSW_LastKey) */
 
@@ -109,11 +110,11 @@ typedef enum {
 	eSW_SnowPack,
 	eSW_DeepSWC,
 	eSW_SoilTemp,
+	eSW_PartsError,
 	/* vegetation quantities */
 	eSW_AllVeg,
-	eSW_Estab,
-	eSW_ErrTemp,
-	eSW_LastKey /* make sure this is the last one */
+	eSW_Estab, /* make sure this is the last one */
+	eSW_LastKey
 } OutKey;
 
 /* output period specifiers found in input file */

--- a/SW_R_lib.c
+++ b/SW_R_lib.c
@@ -318,7 +318,8 @@ SEXP start(SEXP inputOptions, SEXP inputData, SEXP weatherList) {
 	if(periodUse[eSW_WetDays][2]) p_Rwetdays_mo = REAL(GET_SLOT(GET_SLOT(outputData, install("WETDAY")),install("Month")));
 	if(periodUse[eSW_WetDays][1]) p_Rwetdays_wk = REAL(GET_SLOT(GET_SLOT(outputData, install("WETDAY")),install("Week")));
 	if(periodUse[eSW_WetDays][0]) p_Rwetdays_dy = REAL(GET_SLOT(GET_SLOT(outputData, install("WETDAY")),install("Day")));
-	
+
+
 	//Rprintf("Day Pointers Set\n");
 	SW_CTL_main();
 
@@ -2696,6 +2697,7 @@ SEXP onGetOutput(SEXP inputData) {
 		SET_SLOT(swOutput_Object, install(cSWoutput_Names[31]), swOutput_KEY_ESTABL);
 		UNPROTECT(3);
 	}
+
 
 	UNPROTECT(pCount);
 	return swOutput_Object;

--- a/SW_Site.c
+++ b/SW_Site.c
@@ -159,7 +159,7 @@ static LyrIndex _newlayer(void) {
 }
 
 /*static void _clear_layer(LyrIndex n) {
- --------------------------------------------------- 
+ ---------------------------------------------------
 
  memset(SW_Site.lyr[n], 0, sizeof(SW_LAYER_INFO));
 
@@ -648,7 +648,7 @@ void onSet_SW_LYR(SEXP SW_SOILS) {
 			else
 				transp_ok_grass = FALSE;
 		}
-		
+
 		water_eqn(f_gravel, psand, pclay, lyrno);
 		v->lyr[lyrno]->swcBulk_fieldcap = SW_SWPmatric2VWCBulk(f_gravel, 0.333, lyrno) * v->lyr[lyrno]->width;
 		v->lyr[lyrno]->swcBulk_wiltpt = SW_SWPmatric2VWCBulk(f_gravel, 15, lyrno) * v->lyr[lyrno]->width;

--- a/SW_SoilWater.h
+++ b/SW_SoilWater.h
@@ -34,7 +34,6 @@
  modified the use of these variables throughout the rest of the code.
  07/09/2013	(clk)	Added the variables transp_forb, forb_evap, hydred_forb, and forb_int to SW_SOILWAT_OUTPUTS
  Added the variables transpiration_forb, hydred_forb, forb_evap, and forb_int to SW_SOILWAT
- 02/25/2016 (ctd) Added RealD parts to the SW_SOILWAT sub-structure: SW_SOILWAT_OUTPUTS
  */
 /********************************************************/
 /********************************************************/

--- a/SW_SoilWater.h
+++ b/SW_SoilWater.h
@@ -92,8 +92,7 @@ typedef struct {
 			pet,
 			deep,
 			sTemp[MAX_LAYERS], // soil temperature in celcius for each layer
-			surfaceTemp, // soil surface temperature
-			parts[MAX_LAYERS]; // Parton (1978) eq. 2.21 - Using for error testing in Rsoilwat
+			surfaceTemp; // soil surface temperature
 } SW_SOILWAT_OUTPUTS;
 
 typedef struct {
@@ -112,7 +111,6 @@ typedef struct {
 			shrub_int,
 			grass_int,
 			sTemp[MAX_LAYERS],
-			parts[MAX_LAYERS],
 			surfaceTemp; // soil surface temperature
 
 	SW_SOILWAT_OUTPUTS dysum, /* helpful placeholder */

--- a/SW_SoilWater.h
+++ b/SW_SoilWater.h
@@ -34,7 +34,7 @@
  modified the use of these variables throughout the rest of the code.
  07/09/2013	(clk)	Added the variables transp_forb, forb_evap, hydred_forb, and forb_int to SW_SOILWAT_OUTPUTS
  Added the variables transpiration_forb, hydred_forb, forb_evap, and forb_int to SW_SOILWAT
-
+ 02/25/2016 (ctd) Added RealD parts to the SW_SOILWAT sub-structure: SW_SOILWAT_OUTPUTS
  */
 /********************************************************/
 /********************************************************/
@@ -92,7 +92,8 @@ typedef struct {
 			pet,
 			deep,
 			sTemp[MAX_LAYERS], // soil temperature in celcius for each layer
-			surfaceTemp; // soil surface temperature
+			surfaceTemp, // soil surface temperature
+			parts[MAX_LAYERS]; // Parton (1978) eq. 2.21 - Using for error testing in Rsoilwat
 } SW_SOILWAT_OUTPUTS;
 
 typedef struct {
@@ -111,6 +112,7 @@ typedef struct {
 			shrub_int,
 			grass_int,
 			sTemp[MAX_LAYERS],
+			parts[MAX_LAYERS],
 			surfaceTemp; // soil surface temperature
 
 	SW_SOILWAT_OUTPUTS dysum, /* helpful placeholder */

--- a/SW_SoilWater.h
+++ b/SW_SoilWater.h
@@ -91,7 +91,8 @@ typedef struct {
 			pet,
 			deep,
 			sTemp[MAX_LAYERS], // soil temperature in celcius for each layer
-			surfaceTemp; // soil surface temperature
+			surfaceTemp,
+			parts[MAX_LAYERS]; // soil surface temperature
 } SW_SOILWAT_OUTPUTS;
 
 typedef struct {
@@ -110,7 +111,8 @@ typedef struct {
 			shrub_int,
 			grass_int,
 			sTemp[MAX_LAYERS],
-			surfaceTemp; // soil surface temperature
+			surfaceTemp,
+			parts[MAX_LAYERS]; // soil surface temperature
 
 	SW_SOILWAT_OUTPUTS dysum, /* helpful placeholder */
 	wksum, mosum, yrsum, /* accumulators for *avg */


### PR DESCRIPTION
These changes coincide with the modifications in the Soilwat_R_Wrapper repository to account for soil temperature errors based on matric density values.

-There is not implementation to modify soil temperature values in the case of an error, but there is a flag that checks for soil temperature errors
-The flag can then be checked in R through the wrapper

Author:
@charlieduso